### PR TITLE
support branches by ignoring merge commits

### DIFF
--- a/scripts/latex-git-log/latex-git-log
+++ b/scripts/latex-git-log/latex-git-log
@@ -129,7 +129,7 @@ say '\endfoot
 # git log --pretty=format:'%ai'
 # git log --date=short --pretty=format:'%ad'
 my @lines;
-my @git_command = qw(git log --date=short --shortstat);
+my @git_command = qw(git log --date=short --shortstat --no-merges);
 if ($print_author) {
     push( @git_command, qq(--pretty=format:%H & %an NoTinAuthorFiled& %ad & $git_command_commit_msg) );
 }


### PR DESCRIPTION
Hi,

this PR fixes/works around the following issue:

given the below git tree, latex-git-log will...

* fail with `Did not match the commit hash` as soon as an other commit is added on top of branch (feedback) and latex-git-log is executed on that new commit. It will also produce invalid latex code because the (incomplete) table is missing ` \end{longtable}`
* produce valid latex code but not include bf9baa4 in the latex table if executed on HEAD
* produce valid latex code and include 1b2b7aa in the table when run on (master), i.e. work as expected

```
*   bf9baa4 (HEAD -> feedback) Merge branch 'feedback02' into feedback
|\  
| * e3e536a (feedback02) commit msg
* | 70adb7f (feedback01) commit msg
|/  
* 1b2b7aa (master) commit msg
* c712298 commit msg
* 6227266 commit msg
* d5c5b55 commit msg
```
I tested this successfully on git trees with several branches that deviated from (master) with several commits.
