### PR TITLE
latex-git-log: Add file arguments

### DIFF
--- a/scripts/latex-git-log/README.md
+++ b/scripts/latex-git-log/README.md
@@ -2,6 +2,8 @@
 
 This program will output the entire version history as table written in LaTeX
 if it is executed within a git repository.
+When file argument(s) are given, only the history that changed these file(s)
+will be output.
 
 It is intended that you redirect the standard output of this script to a file which can then be included from your main LaTeX document.
 
@@ -40,7 +42,7 @@ Please report bugs and feature requests at https://github.com/ypid/typesetting/i
 
 ## Usage
 
-    latex-git-log [options]
+    latex-git-log [options] [file] ...
 
     Options:
 

--- a/scripts/latex-git-log/latex-git-log
+++ b/scripts/latex-git-log/latex-git-log
@@ -130,6 +130,12 @@ else {
 if ($revision_range) {
     push( @git_command, qq($revision_range) );
 }
+
+# check for command-line file arguments
+if ($#ARGV >= 0) {
+    push( @git_command, ("--", @ARGV) );
+}
+
 @lines = reverse capturex(@git_command);
 # }}}
 
@@ -235,7 +241,7 @@ latex-git-log - Generates the version history of a git project as LaTeX source c
 
 =head1 Synopsis
 
-latex-git-log [options]
+latex-git-log [options] [file] ...
 
 Options:
 
@@ -313,6 +319,8 @@ table is not complete and will be continued.
 
 B<This program> will output the entire version history as table written in
 LaTeX if it is executed within a git repository.
+When I<file> argument(s) are given, only the history that changed these file(s)
+will be output.
 
 It is intended that you redirect the standard output of this script to a file
 which can then be included from your main LaTeX document.


### PR DESCRIPTION
Added file arguments to latex-git-log. If these are given, only the history that affects these files will be generated. Typically this will be only the file(s) that make up one document. 