### PR TITLE
Fix the use of "\iflanguage" (supported by babel only) causing compilation failure in lualatex

### DIFF
--- a/MyPackages/languageBaseRS.sty
+++ b/MyPackages/languageBaseRS.sty
@@ -31,10 +31,20 @@
 }
 
 \newcommand{\printlanguage}{%
+\ifPDFTeX%
 \iflanguage{ngerman}{Deutsch (neue Rechtschreibung)}{%
   \iflanguage{english}{Englisch}{%
   \iflanguage{british}{Britisches Englisch}{\textcolor{red}{\languagename}}
   }
-}}
+}
+\fi
+\ifLuaTeX%
+\iflanguageloaded{ngerman}{Deutsch (neue Rechtschreibung)}{%
+  \iflanguageloaded{english}{Englisch}{%
+  \iflanguageloaded{british}{Britisches Englisch}{\textcolor{red}{\languagename}}
+  }
+}
+\fi
+}
 
 \endinput

--- a/MyPackages/letterRS.sty
+++ b/MyPackages/letterRS.sty
@@ -76,20 +76,35 @@
 }
 
 \newcommand{\letterRS@letterOpeningLine}[2]{%
+\ifPDFTeX%
   \iflanguage{ngerman}{
+\fi
+\ifLuaTeX%
+  \iflanguageloaded{ngerman}{
+\fi
     \ifthenelse{\equal{#1}{m}}{Sehr geehrter Herr #2,}{}
     \ifthenelse{\equal{#1}{w}}{Sehr geehrte Frau #2,}{}
     \ifthenelse{\equal{#1}{f}}{Sehr geehrte Familie #2,}{}
     \ifthenelse{\equal{#1}{dh}}{Sehr geehrte Damen und Herren,}{}
   }{%
+    \ifPDFTeX%
     \iflanguage{english}{
+    \fi
+    \ifLuaTeX%
+    \iflanguageloaded{english}{
+    \fi
       %% https://www.linkedin.com/groups/Writing-in-letter-in-English-4319755.S.121829504
       \ifthenelse{\equal{#1}{m}}{Dear Mr.~#2,}{}
       \ifthenelse{\equal{#1}{w}}{Dear Ms.~#2,}{}
       \ifthenelse{\equal{#1}{f}}{Dear Family #2,}{}
       \ifthenelse{\equal{#1}{dh}}{Dear Sir or Madam,}{}
     }{
+      \ifPDFTeX%
       \iflanguage{UKenglish}{
+      \fi
+      \ifLuaTeX%
+      \iflanguageloaded{UKenglish}{
+      \fi
         %% https://www.linkedin.com/groups/Writing-in-letter-in-English-4319755.S.121829504
         \ifthenelse{\equal{#1}{m}}{Dear Mr.~#2,}{}
         \ifthenelse{\equal{#1}{w}}{Dear Ms.~#2,}{}

--- a/MyPackages/timeRS.sty
+++ b/MyPackages/timeRS.sty
@@ -20,12 +20,12 @@
 
 %% Ugly hack to make german the default language for isodate in case when language detection fails e.g. with LuaLaTeX. Use from document.
 
-\iflanguage{ngerman}{
-  \ifLuaTeX%
-    \def\CurrentOption{german}
-    \input{german.idf}
-  \fi
+\ifLuaTeX%
+\iflanguageloaded{ngerman}{
+  \def\CurrentOption{german}
+  \input{german.idf}
 }{}
+\fi
 
 % \@namedef{iso@rangesign@english}{~s to~}%
 

--- a/scripts/latex-git-wdiff
+++ b/scripts/latex-git-wdiff
@@ -46,7 +46,12 @@ grep -v "\^\[\[1mdiff --git a" \
 }
 
 echoVersionstable (){
-echo '\iflanguage{ngerman}{\shorthandoff{"}}{}
+echo '\ifPDFTeX%
+\iflanguage{ngerman}{\shorthandoff{"}}{}
+\fi
+\ifLuaTeX%
+\iflanguageloaded{ngerman}{\shorthandoff{"}}{}
+\fi
 \renewcommand{\longtableheader}{\hline \multicolumn{1}{|c}{\textbf{Tag}}
 & \multicolumn{1}{c}{\textbf{Hash}}
 & \multicolumn{1}{c}{\textbf{Erstellungsdatum}}


### PR DESCRIPTION
## Motivation of the Changes

I realize the output file generated by `latex-git-log` contains the statement:

```latex
\iflanguage{ngerman}{\shorthandoff{"}}{}
```

This works fine with `pdflatex` but would fail the compilation by `lualatex`.  It seems to me the reason is that the macro `\iflanguage` is defined in `babel` but for `lualatex` the package `polyglossia` is used instead of `babel`.

In `polyglossia`, the equivalent macro is `\iflanguageloaded`.  So I've made this pull request to conditionally use one of the two macros depending on the compiler in use.

Hope this make sense.

## Testing

I am not sure how unit testing or testing is generally done in this repo.  I'd appreciate any pointer or advice.